### PR TITLE
Add NotAuthorizedException handler for JWT authentication failures

### DIFF
--- a/error-quarkus/src/main/kotlin/org/incept5/error/RestErrorHandler.kt
+++ b/error-quarkus/src/main/kotlin/org/incept5/error/RestErrorHandler.kt
@@ -90,6 +90,20 @@ open class RestErrorHandler {
         return handleCoreException(req, toCoreException(ErrorCategory.VALIDATION, exp, "Method Not Allowed"))
     }
 
+    /**
+     * Handle JWT authentication failures
+     * This mapper catches NotAuthorizedException that are thrown by Quarkus SmallRye JWT
+     * authentication when JWT validation fails (invalid/expired tokens, missing auth headers, etc.)
+     */
+    @ServerExceptionMapper
+    fun handleNotAuthorizedException(
+        req: HttpServerRequest,
+        exp: NotAuthorizedException,
+    ): Response {
+        Log.debug("Authentication failed: ${exp.message}")
+        return handleCoreException(req, toCoreException(ErrorCategory.AUTHENTICATION, exp, "Authentication required"))
+    }
+
     @ServerExceptionMapper
     @Priority(Priorities.USER - 100) // High priority to catch before other handlers
     fun handleBadRequestException(

--- a/error-quarkus/src/test/kotlin/org/incept5/error/RestErrorHandlerTest.kt
+++ b/error-quarkus/src/test/kotlin/org/incept5/error/RestErrorHandlerTest.kt
@@ -9,6 +9,7 @@ import io.vertx.core.http.HttpServerRequest
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.net.SocketAddress
 import jakarta.ws.rs.BadRequestException
+import jakarta.ws.rs.NotAuthorizedException
 import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
 import org.junit.jupiter.api.Assertions.*
@@ -206,6 +207,21 @@ class RestErrorHandlerTest {
         
         val entity = response.entity as org.incept5.error.response.CommonErrorResponse
         assertEquals("currency.items.[0]", entity.errors[0].location)
+    }
+
+    @Test
+    fun `handleNotAuthorizedException should return unauthorized error response`() {
+        // Create a NotAuthorizedException as would be thrown by Quarkus SmallRye JWT
+        val exception = NotAuthorizedException("JWT authentication failed")
+        
+        val response = restErrorHandler.handleNotAuthorizedException(mockRequest, exception)
+        
+        assertEquals(Response.Status.UNAUTHORIZED.statusCode, response.status)
+        
+        val entity = response.entity as org.incept5.error.response.CommonErrorResponse
+        assertEquals(1, entity.errors.size)
+        assertEquals("AUTHENTICATION", entity.errors[0].code)
+        assertEquals("Authentication required", entity.errors[0].message)
     }
 
     // Test enum for use in tests


### PR DESCRIPTION
Handles NotAuthorizedException when there is JWT auth failures