### PR TITLE
Add BAD_GATEWAY error category and map it to HTTP 502

### DIFF
--- a/error-core/src/main/kotlin/org/incept5/error/ErrorCategory.kt
+++ b/error-core/src/main/kotlin/org/incept5/error/ErrorCategory.kt
@@ -9,5 +9,6 @@ enum class ErrorCategory {
     VALIDATION,
     CONFLICT,
     NOT_FOUND,
+    BAD_GATEWAY,
     UNEXPECTED,
 }

--- a/error-quarkus/src/main/kotlin/org/incept5/error/RestErrorHandler.kt
+++ b/error-quarkus/src/main/kotlin/org/incept5/error/RestErrorHandler.kt
@@ -44,6 +44,10 @@ open class RestErrorHandler {
             if ( exp.category == ErrorCategory.UNEXPECTED ) {
                 // unexpected exceptions are logged to ERROR and the full stacktrace appears in the logs
                 Log.error("Unexpected exception encountered : ${requestLog(req)}", exp)
+            } else if ( exp.category == ErrorCategory.BAD_GATEWAY ) {
+                // upstream/gateway failures are 5xx server-side errors: log to ERROR with the full
+                // stacktrace so the failing upstream dependency can be diagnosed
+                Log.error("Bad gateway exception encountered : ${requestLog(req)}", exp)
             } else {
                 // all other exceptions are logged to WARN and the message and first 10 lines of the root cause appear in the logs
                 Log.warn("Application exception encountered : ${requestLog(req, exp)}")
@@ -406,6 +410,7 @@ open class RestErrorHandler {
             ErrorCategory.VALIDATION -> Response.Status.BAD_REQUEST
             ErrorCategory.CONFLICT -> Response.Status.CONFLICT
             ErrorCategory.NOT_FOUND -> Response.Status.NOT_FOUND
+            ErrorCategory.BAD_GATEWAY -> Response.Status.BAD_GATEWAY
             ErrorCategory.UNEXPECTED -> Response.Status.INTERNAL_SERVER_ERROR
         }
     }

--- a/error-quarkus/src/test/kotlin/org/incept5/error/RestErrorHandlerTest.kt
+++ b/error-quarkus/src/test/kotlin/org/incept5/error/RestErrorHandlerTest.kt
@@ -224,6 +224,26 @@ class RestErrorHandlerTest {
         assertEquals("Authentication required", entity.errors[0].message)
     }
 
+    @Test
+    fun `handleCoreException should map BAD_GATEWAY category to 502 response`() {
+        val exception = CoreException(
+            ErrorCategory.BAD_GATEWAY,
+            listOf(Error("BAD_GATEWAY")),
+            "Upstream service unavailable",
+            RuntimeException("connection refused")
+        )
+
+        val response = restErrorHandler.handleCoreException(mockRequest, exception)
+
+        assertEquals(Response.Status.BAD_GATEWAY.statusCode, response.status)
+
+        val entity = response.entity as org.incept5.error.response.CommonErrorResponse
+        assertEquals(Response.Status.BAD_GATEWAY.statusCode, entity.httpStatusCode)
+        assertEquals(1, entity.errors.size)
+        assertEquals("BAD_GATEWAY", entity.errors[0].code)
+        assertEquals("Upstream service unavailable", entity.errors[0].message)
+    }
+
     // Test enum for use in tests
     enum class TestEnum {
         VALUE1, VALUE2, VALUE3


### PR DESCRIPTION
## Summary

Adds a new `BAD_GATEWAY` error category so callers can signal upstream/gateway failures, and wires it through `RestErrorHandler`.

- **`ErrorCategory.kt`** — new `BAD_GATEWAY` enum value.
- **`RestErrorHandler.kt`**
  - `mapErrorCategoryToHttpStatus()` maps `BAD_GATEWAY → Response.Status.BAD_GATEWAY` (HTTP 502).
  - `handleCoreException()` logs `BAD_GATEWAY` at ERROR with the full stacktrace (like `UNEXPECTED`), since 502 is a server-side failure where the failing upstream dependency needs diagnosing — rather than the terse WARN used for 4xx client errors.
- **`RestErrorHandlerTest.kt`** — test asserting a `BAD_GATEWAY` `CoreException` yields a 502 with the correct code, message, and `httpStatusCode`.

Usage:

```kotlin
throw CoreException(ErrorCategory.BAD_GATEWAY, listOf(Error("BAD_GATEWAY")), "Upstream service unavailable", cause)
// or non-intrusively:
someUpstreamException.addMetadata(ErrorCategory.BAD_GATEWAY, Error("BAD_GATEWAY"))
```

## Testing

`./gradlew test` — all 22 tasks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)