### PR TITLE
Add RATE_LIMIT_EXCEEDED error category and map it to HTTP 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ The library defines several error categories that map to appropriate HTTP status
 
 ```kotlin
 enum class ErrorCategory {
-    AUTHENTICATION,    // 401 Unauthorized
-    AUTHORIZATION,     // 403 Forbidden
-    VALIDATION,        // 400 Bad Request
-    CONFLICT,          // 409 Conflict
-    NOT_FOUND,         // 404 Not Found
-    UNEXPECTED,        // 500 Internal Server Error
+    AUTHENTICATION,      // 401 Unauthorized
+    AUTHORIZATION,       // 403 Forbidden
+    VALIDATION,          // 400 Bad Request
+    CONFLICT,            // 409 Conflict
+    NOT_FOUND,           // 404 Not Found
+    BAD_GATEWAY,         // 502 Bad Gateway
+    RATE_LIMIT_EXCEEDED, // 429 Too Many Requests (with Retry-After header)
+    UNEXPECTED,          // 500 Internal Server Error
 }
 ```
 
@@ -152,6 +154,29 @@ if (exception.isRetryable()) {
     // Implement retry logic
 }
 ```
+
+### Rate Limit Errors
+
+When a caller exceeds a rate limit, throw `RateLimitExceededException` (or any `CoreException`
+with the `RATE_LIMIT_EXCEEDED` category) from your throttling site:
+
+```kotlin
+throw RateLimitExceededException(
+    message = "Rate limit exceeded. Maximum 10 requests per minute allowed.",
+    retryAfterSeconds = 30, // optional, defaults to 60 in the response header
+)
+```
+
+In Quarkus the handler maps this to an HTTP 429 (Too Many Requests) response with a
+`Retry-After` header set from `retryAfterSeconds` (or `60` if not supplied). The exception
+is always retryable.
+
+Note that the library logs rate limit errors at DEBUG rather than WARN, on the assumption
+that the throttling site (e.g. an interceptor) already logs each rejection with its own
+context (bucket key, limit, client) — this avoids double-logging every throttled request.
+
+This library only standardises the 429 *response*; it does not provide a rate limiting
+mechanism. For annotation-driven endpoint throttling see `@RateLimit` in `platform-core-lib`.
 
 ## Quarkus Integration
 

--- a/error-core/src/main/kotlin/org/incept5/error/ErrorCategory.kt
+++ b/error-core/src/main/kotlin/org/incept5/error/ErrorCategory.kt
@@ -10,5 +10,6 @@ enum class ErrorCategory {
     CONFLICT,
     NOT_FOUND,
     BAD_GATEWAY,
+    RATE_LIMIT_EXCEEDED,
     UNEXPECTED,
 }

--- a/error-core/src/main/kotlin/org/incept5/error/RateLimitExceededException.kt
+++ b/error-core/src/main/kotlin/org/incept5/error/RateLimitExceededException.kt
@@ -1,0 +1,22 @@
+package org.incept5.error
+
+/**
+ * Convenience exception for signalling that a caller has exceeded a rate limit.
+ *
+ * Maps to HTTP 429 (Too Many Requests) in the transport layer. If retryAfterSeconds
+ * is supplied it is emitted as the Retry-After response header, otherwise a default
+ * is applied by the transport layer.
+ *
+ * Rate limit errors are transient by nature, so these exceptions are always retryable.
+ */
+open class RateLimitExceededException(
+    message: String,
+    val retryAfterSeconds: Long? = null,
+    cause: Throwable? = null,
+) : CoreException(
+    ErrorCategory.RATE_LIMIT_EXCEEDED,
+    listOf(Error(ErrorCategory.RATE_LIMIT_EXCEEDED.name)),
+    message,
+    cause,
+    retryable = true,
+)

--- a/error-quarkus/src/main/kotlin/org/incept5/error/RestErrorHandler.kt
+++ b/error-quarkus/src/main/kotlin/org/incept5/error/RestErrorHandler.kt
@@ -29,6 +29,7 @@ open class RestErrorHandler {
 
     companion object {
         private val objectMapper = ObjectMapper()
+        private const val DEFAULT_RETRY_AFTER_SECONDS = 60L
     }
 
     /**
@@ -48,6 +49,10 @@ open class RestErrorHandler {
                 // upstream/gateway failures are 5xx server-side errors: log to ERROR with the full
                 // stacktrace so the failing upstream dependency can be diagnosed
                 Log.error("Bad gateway exception encountered : ${requestLog(req)}", exp)
+            } else if ( exp.category == ErrorCategory.RATE_LIMIT_EXCEEDED ) {
+                // the throttling site (interceptor or controller) typically WARN-logs with its own context;
+                // debug here avoids double-logging every throttled request
+                Log.debug("Rate limit exceeded : ${requestLog(req, exp)}")
             } else {
                 // all other exceptions are logged to WARN and the message and first 10 lines of the root cause appear in the logs
                 Log.warn("Application exception encountered : ${requestLog(req, exp)}")
@@ -58,9 +63,14 @@ open class RestErrorHandler {
                     CorrelationId.getId(),
                     mapErrorCategoryToHttpStatus(exp.category).statusCode,
                 )
-            Response
+            val builder = Response
                 .status(mapErrorCategoryToHttpStatus(exp.category))
-                .entity(response).build()
+                .entity(response)
+            if (exp.category == ErrorCategory.RATE_LIMIT_EXCEEDED) {
+                val retryAfterSeconds = (exp as? RateLimitExceededException)?.retryAfterSeconds ?: DEFAULT_RETRY_AFTER_SECONDS
+                builder.header("Retry-After", retryAfterSeconds.toString())
+            }
+            builder.build()
         } catch (t: Throwable) {
             Log.error("Failed to generate error response", exp)
             handleUnexpectedException(req, t)
@@ -411,6 +421,7 @@ open class RestErrorHandler {
             ErrorCategory.CONFLICT -> Response.Status.CONFLICT
             ErrorCategory.NOT_FOUND -> Response.Status.NOT_FOUND
             ErrorCategory.BAD_GATEWAY -> Response.Status.BAD_GATEWAY
+            ErrorCategory.RATE_LIMIT_EXCEEDED -> Response.Status.TOO_MANY_REQUESTS
             ErrorCategory.UNEXPECTED -> Response.Status.INTERNAL_SERVER_ERROR
         }
     }

--- a/error-quarkus/src/test/kotlin/org/incept5/error/RestErrorHandlerTest.kt
+++ b/error-quarkus/src/test/kotlin/org/incept5/error/RestErrorHandlerTest.kt
@@ -244,6 +244,42 @@ class RestErrorHandlerTest {
         assertEquals("Upstream service unavailable", entity.errors[0].message)
     }
 
+    @Test
+    fun `handleCoreException should map RATE_LIMIT_EXCEEDED category to 429 response with default Retry-After`() {
+        val exception = CoreException(
+            ErrorCategory.RATE_LIMIT_EXCEEDED,
+            listOf(Error("RATE_LIMIT_EXCEEDED")),
+            "Too many requests"
+        )
+
+        val response = restErrorHandler.handleCoreException(mockRequest, exception)
+
+        assertEquals(Response.Status.TOO_MANY_REQUESTS.statusCode, response.status)
+        assertEquals("60", response.getHeaderString("Retry-After"))
+
+        val entity = response.entity as org.incept5.error.response.CommonErrorResponse
+        assertEquals(Response.Status.TOO_MANY_REQUESTS.statusCode, entity.httpStatusCode)
+        assertEquals(1, entity.errors.size)
+        assertEquals("RATE_LIMIT_EXCEEDED", entity.errors[0].code)
+        assertEquals("Too many requests", entity.errors[0].message)
+    }
+
+    @Test
+    fun `handleCoreException should use retryAfterSeconds from RateLimitExceededException`() {
+        val exception = RateLimitExceededException("Rate limit exceeded for bucket api-key-123", retryAfterSeconds = 30)
+
+        val response = restErrorHandler.handleCoreException(mockRequest, exception)
+
+        assertEquals(Response.Status.TOO_MANY_REQUESTS.statusCode, response.status)
+        assertEquals("30", response.getHeaderString("Retry-After"))
+        assertTrue(exception.isRetryable())
+
+        val entity = response.entity as org.incept5.error.response.CommonErrorResponse
+        assertEquals(1, entity.errors.size)
+        assertEquals("RATE_LIMIT_EXCEEDED", entity.errors[0].code)
+        assertEquals("Rate limit exceeded for bucket api-key-123", entity.errors[0].message)
+    }
+
     // Test enum for use in tests
     enum class TestEnum {
         VALUE1, VALUE2, VALUE3


### PR DESCRIPTION
Introduce a RATE_LIMIT_EXCEEDED ErrorCategory and a RateLimitExceededException convenience class (carrying an optional retryAfterSeconds, always retryable) so calling services can replace their custom RateLimitExceededException mappers with the standard handler.

RestErrorHandler maps the category to HTTP 429 (Too Many Requests) and sets the Retry-After header from the exception's retryAfterSeconds, defaulting to
60. Rate limit errors are logged at DEBUG rather than WARN since the throttling site (e.g. an interceptor) already logs each rejection with its own context, and double-logging every throttled request would clutter logs.

Document the new category, exception, response behaviour and the division of responsibility with platform-core-lib's @RateLimit interceptor in the README.